### PR TITLE
Add manual scroll listener for non-document scroll events

### DIFF
--- a/lazy-img.html
+++ b/lazy-img.html
@@ -12,14 +12,6 @@ Example:
 @demo demo/index.html
 
 -->
-<dom-module id="lazy-img">
-
-  <template>
-    <content></content>
-  </template>
-
-</dom-module>
-
 <script>
 
   var inViewport = function(el) {
@@ -67,17 +59,14 @@ Example:
       this.original = this.src;
       this.src = this.fallbackImage;
 
-      // Our default listener task (for sanity's sake)
-      this.listener = function() { /* noop */ };
-      
       // Check if Element is in viewport      
       if (inViewport(this)) {
         // Set src if it is valid
         this.src = this.original;
       } else {
         // Register scroll listener if it is not
-        this.listener = this._handleScroll.bind(this);
-        document.addEventListener('scroll', this.listener);
+        this.listen(window, 'scroll', '_handleScroll');
+        this.listen(window, 'lazy-img-manual-scroll', '_handleScroll');
       }
     },
 
@@ -93,7 +82,8 @@ Example:
       }.bind(this));
     },
     _clearScroll: function() {
-      document.removeEventListener('scroll', this.listener);
+      this.unlisten(window, 'scroll', '_handleScroll');
+      this.unlisten(window, 'lazy-img-manual-scroll', '_handleScroll');
     }
   });
 


### PR DESCRIPTION
The component is currently listening for a scroll event on `document`. When the scroll is not triggered from the `document` but rather an internal scrolling div the scroll handler does not fire. My proposal is to add an additional listener for `lazy-img-manual-scroll` in case the image is nested in a scrolling div.

I removed the `<dom-module>` as it was throwing an error about creating a shadowRoot for an image. I also refactored your event listeners to use `this.listen`/`this.unlisten` rather than utilizing the `this.listener` function.
